### PR TITLE
Fix for check_mut_ref

### DIFF
--- a/janetrs_macros/src/lib.rs
+++ b/janetrs_macros/src/lib.rs
@@ -61,35 +61,23 @@ pub fn janet_fn(
                 quote! {}
             },
             Arg::CheckMutRef => quote! {
-                for j1 in &args[0..args.len() - 1] {
-                    for j2 in &args[1..] {
-                        if matches!(
-                            j1.kind(),
-                            ::janetrs::JanetType::Array
-                                | ::janetrs::JanetType::Buffer
-                                | ::janetrs::JanetType::CFunction
-                                | ::janetrs::JanetType::Fiber
-                                | ::janetrs::JanetType::Function
-                                | ::janetrs::JanetType::Keyword
-                                | ::janetrs::JanetType::Pointer
-                                | ::janetrs::JanetType::Symbol
-                                | ::janetrs::JanetType::Table
-                        ) && matches!(
-                            j1.kind(),
-                            ::janetrs::JanetType::Array
-                                | ::janetrs::JanetType::Buffer
-                                | ::janetrs::JanetType::CFunction
-                                | ::janetrs::JanetType::Fiber
-                                | ::janetrs::JanetType::Function
-                                | ::janetrs::JanetType::Keyword
-                                | ::janetrs::JanetType::Pointer
-                                | ::janetrs::JanetType::Symbol
-                                | ::janetrs::JanetType::Table
-                        ) && j1 == j2
-                        {
-                            ::janetrs::jpanic!("Received two mutable references as arguments");
-                        }
-                    }
+                if (1..args.len()).any(|i| {
+                    let a = args[i - 1];
+                    matches!(
+                        a.kind(),
+                        ::janetrs::JanetType::Abstract
+                            | ::janetrs::JanetType::Array
+                            | ::janetrs::JanetType::Buffer
+                            | ::janetrs::JanetType::CFunction
+                            | ::janetrs::JanetType::Fiber
+                            | ::janetrs::JanetType::Function
+                            | ::janetrs::JanetType::Keyword
+                            | ::janetrs::JanetType::Pointer
+                            | ::janetrs::JanetType::Symbol
+                            | ::janetrs::JanetType::Table
+                    ) && args[i..].contains(&a)
+                }) {
+                    ::janetrs::jpanic!("Received two mutable references as arguments");
                 }
             },
             Arg::Arity(ArityArgs::Fix(n)) => quote! {


### PR DESCRIPTION
There is a bug with `check_mut_ref` where it will always panic on the second arg or any later arg for the specified kinds (if the number of args is greater than 2). The version I'm submitting only checks each arg against the following args. It also only checks the kind against one arg since, if they are equal, the kind is the same. I also added the Abstract kind to the match pattern since you can get mutable refs from it.

There are no actual tests for this. Should I add one?