### PR TITLE
Add feature check to doctests

### DIFF
--- a/src/types/tuple.rs
+++ b/src/types/tuple.rs
@@ -615,6 +615,9 @@ impl<'data> JanetTuple<'data> {
     /// # Panics
     ///
     /// Panics if `size` is 0.
+    #[cfg_attr(
+        any(feature = "amalgation", feature = "link-system"),
+        doc = r##"
     ///
     /// # Examples
     ///
@@ -640,6 +643,8 @@ impl<'data> JanetTuple<'data> {
     /// let mut iter = arr.windows(4);
     /// assert!(iter.next().is_none());
     /// ```
+    "##
+    )]
     #[inline]
     pub fn windows(&self, size: usize) -> Windows<'_, Janet> {
         self.as_ref().windows(size)


### PR DESCRIPTION
I noticed many doctests fail since `JanetClient` isn't in the default feature set. The doctests can be wrapped with `#[cfg_attr(..., doc = "...")]` to skip them with the default features. I can do the rest if you think this is worth the effort (there's a lot). Or, just close if not.