### PR TITLE
Use UFCS for `utf8_chunks`

### DIFF
--- a/src/types/buffer.rs
+++ b/src/types/buffer.rs
@@ -2392,7 +2392,7 @@ impl JanetBuffer<'_> {
     /// [`to_str_lossy`]: #method.to_str_lossy
     #[inline]
     pub fn utf8_chunks(&self) -> Utf8Chunks {
-        self.as_bytes().utf8_chunks()
+        ByteSlice::utf8_chunks(self.as_bytes())
     }
 
     /// Creates an iterator over the words in this buffer along with

--- a/src/types/string.rs
+++ b/src/types/string.rs
@@ -2114,7 +2114,7 @@ impl<'data> JanetString<'data> {
     /// [`to_str_lossy`]: #method.to_str_lossy
     #[inline]
     pub fn utf8_chunks(&self) -> Utf8Chunks {
-        self.as_bytes().utf8_chunks()
+        ByteSlice::utf8_chunks(self.as_bytes())
     }
 
     /// Creates an iterator over the words in this string along with


### PR DESCRIPTION
https://github.com/rust-lang/rust/pull/123909 will add a `utf8_chunks` method to `[u8]`, which will conflict with the method provided by `bstr`. To make this crate resilient against that change, regardless of how the [discussion](https://github.com/rust-lang/rust/issues/99543) around it is resolved, this PR changes the relevant lines to use UFCS which tells the compiler to prefer the `bstr` method.