### PR TITLE
Fix refined error spans.

### DIFF
--- a/janetrs_macros/tests/01-paths.stderr
+++ b/janetrs_macros/tests/01-paths.stderr
@@ -8,10 +8,10 @@ error: expected to be a `janetrs::Janet`
   --> tests/01-paths:12:31
    |
 12 | pub fn function2(_args: &mut [tips::Janet]) -> types::Janet {
-   |                               ^^^^^^^^^^^
+   |                               ^^^^
 
 error: expected to be a `janetrs::Janet`
   --> tests/01-paths:17:31
    |
 17 | pub fn function3(_args: &mut [types::Janet]) {}
-   |                               ^^^^^^^^^^^^
+   |                               ^^^^^

--- a/janetrs_macros/tests/02-not-function.stderr
+++ b/janetrs_macros/tests/02-not-function.stderr
@@ -2,4 +2,4 @@ error: expected fn item
  --> tests/02-not-function:4:1
   |
 4 | struct A(i32);
-  | ^^^^^^^^^^^^^^
+  | ^^^^^^

--- a/janetrs_macros/tests/03-not-mut.stderr
+++ b/janetrs_macros/tests/03-not-mut.stderr
@@ -2,4 +2,4 @@ error: expected argument to be a mutable reference and found a immutable referen
  --> tests/03-not-mut:7:24
   |
 7 | pub fn function(_args: &[Janet]) -> Janet {
-  |                        ^^^^^^^^
+  |                        ^

--- a/janetrs_macros/tests/05-wrong-args.stderr
+++ b/janetrs_macros/tests/05-wrong-args.stderr
@@ -2,4 +2,4 @@ error: expected exactly one argument of type `&mut [janetrs::Janet]`
  --> tests/05-wrong-args:7:17
   |
 7 | pub fn function(_args: &mut [Janet], _wrong: Janet) -> Janet {
-  |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  |                 ^^^^^

--- a/janetrs_macros/tests/08-wrong-args.stderr
+++ b/janetrs_macros/tests/08-wrong-args.stderr
@@ -32,7 +32,7 @@ error: repeated argument kind: There must be only one argument of each kind, tha
   --> tests/08-wrong-args:30:12
    |
 30 | #[janet_fn(check_mut_ref, check_mut_ref)]
-   |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |            ^^^^^^^^^^^^^
 
 error: expected a maximum of two arguments to the janet_fn proc-macro
   --> tests/08-wrong-args:35:42

--- a/janetrs_macros/tests/09-version-wrong.stderr
+++ b/janetrs_macros/tests/09-version-wrong.stderr
@@ -31,7 +31,7 @@ error: invalid string literal: invalid digit found in string
    |                      ^^^^^
 
 error: expected at max two arguments to the janet_version proc-macro
-  --> tests/09-version-wrong:28:17
+  --> tests/09-version-wrong:28:27
    |
 28 | #[janet_version("1", "2", "3")]
-   |                 ^^^^^^^^^^^^^
+   |                           ^^^


### PR DESCRIPTION
I'm on Rust 1.79 and I can't find any reference to this in the release notes, but I think they refined the error spans for some errors.