### PR TITLE
Add basic unmarshaling

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -142,6 +142,12 @@ impl JanetClient {
         Ok(client)
     }
 
+    #[inline]
+    pub fn load_env(mut self, env: JanetEnvironment) -> Self {
+        self.env_table = Some(env);
+        self
+    }
+
     /// Load the default environment of Janet.
     ///
     /// The default environment of Janet contains all the Janet C code as well as the

--- a/src/client.rs
+++ b/src/client.rs
@@ -337,6 +337,24 @@ impl JanetClient {
         self.run_bytes(code.as_bytes())
     }
 
+    #[inline]
+    pub fn unmarshal(&self, image: impl AsRef<[u8]>) -> Janet {
+        let image = image.as_ref();
+        let marsh_out = unsafe {
+            use evil_janet::*;
+            let env = janet_core_env(std::ptr::null_mut());
+            let lookup = janet_env_lookup(env);
+            janet_unmarshal(
+                image.as_ptr(),
+                image.len(),
+                0,
+                lookup,
+                std::ptr::null_mut(),
+            )
+        };
+        Janet::from(marsh_out)
+    }
+
     /// Return a reference of the environment table of the runtime if it exist.
     #[inline]
     #[must_use]

--- a/src/env.rs
+++ b/src/env.rs
@@ -19,9 +19,8 @@ impl JanetEnvironment {
     /// Creates a new environment with Janet default environment.
     #[inline]
     #[must_use = "function is a constructor associated function"]
-    pub fn new() -> Self {
-        // SAFETY: `janet_core_env` never returns a null pointer
-        Self(unsafe { JanetTable::from_raw(evil_janet::janet_core_env(ptr::null_mut())) })
+    pub fn new(table: JanetTable<'static>) -> Self {
+        Self(table)
     }
 
     /// Creates a new environment with Janet default environment and the given `env`
@@ -187,7 +186,8 @@ impl JanetEnvironment {
 
 impl Default for JanetEnvironment {
     fn default() -> Self {
-        Self::new()
+        // SAFETY: `janet_core_env` never returns a null pointer
+        Self(unsafe { JanetTable::from_raw(evil_janet::janet_core_env(ptr::null_mut())) })
     }
 }
 


### PR DESCRIPTION
- add `JanetClient::unmarshal(...)`
- add `JanetClient::laod_env(...)` to laod custom environment
- change `JanetEnvironment::new()` to accept a `JanetTable`. This will allow user to make custom environment from unmarshaled table. `JanetEnvironment::default()` remains same as before.