### PR TITLE
use JanetType instead of hardcoded u32

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,8 +104,6 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 [[package]]
 name = "evil-janet"
 version = "1.37.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e10724408052d8c9f0bb9d920597c81ed7408a165f2cd7273eee83ee254ecfe"
 dependencies = [
  "bindgen",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 bstr = { version = "1.0.0", default-features = false, features = ["alloc"] }
-evil-janet = "1"
+evil-janet = { version = "1", path = "../evil-janet" }
 janetrs_macros = { version = "0.7.3", path = "janetrs_macros" }
 janetrs_version = { version = "0.1.0", path = "janetrs_version" }
 libc = { version = "0.2", default-features = false, features = [

--- a/janetrs_version/Cargo.toml
+++ b/janetrs_version/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["api-bindings"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-evil-janet = "1"
+evil-janet = { version = "1", path = "../../evil-janet" }
 
 [features]
 default = []

--- a/src/types.rs
+++ b/src/types.rs
@@ -19,8 +19,9 @@ use alloc::{
 };
 
 use evil_janet::{
-    JANET_INTMAX_DOUBLE, JANET_INTMIN_DOUBLE, Janet as CJanet, JanetType as CJanetType,
+    JANET_INTMAX_DOUBLE, JANET_INTMIN_DOUBLE, Janet as CJanet
 };
+pub use evil_janet::JanetType as CJanetType;
 
 pub mod array;
 pub mod buffer;
@@ -1540,7 +1541,8 @@ impl From<TaggedJanet<'_>> for Janet {
 
 /// Representation of all Janet types.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[repr(u32)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
 pub enum JanetType {
     Abstract = evil_janet::JanetType_JANET_ABSTRACT,
     Array  = evil_janet::JanetType_JANET_ARRAY,
@@ -1613,7 +1615,7 @@ impl Display for JanetType {
 impl From<JanetType> for CJanetType {
     #[inline]
     fn from(val: JanetType) -> Self {
-        val as u32
+        val as CJanetType
     }
 }
 
@@ -1623,7 +1625,8 @@ impl From<JanetType> for CJanetType {
 /// `Ok`, `Yield` and `User9` usually represents when it worked, the others usually
 /// represents that something went wrong.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[repr(u32)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
 pub enum JanetSignal {
     Ok    = evil_janet::JanetSignal_JANET_SIGNAL_OK,
     Error = evil_janet::JanetSignal_JANET_SIGNAL_ERROR,
@@ -1641,8 +1644,8 @@ pub enum JanetSignal {
     User9 = evil_janet::JanetSignal_JANET_SIGNAL_USER9,
 }
 
-impl From<u32> for JanetSignal {
-    fn from(val: u32) -> Self {
+impl From<CJanetType> for JanetSignal {
+    fn from(val: CJanetType) -> Self {
         match val {
             evil_janet::JanetSignal_JANET_SIGNAL_OK => Self::Ok,
             evil_janet::JanetSignal_JANET_SIGNAL_ERROR => Self::Error,
@@ -1663,7 +1666,7 @@ impl From<u32> for JanetSignal {
     }
 }
 
-impl From<JanetSignal> for u32 {
+impl From<JanetSignal> for CJanetType {
     fn from(val: JanetSignal) -> Self {
         val as _
     }

--- a/src/types/fiber.rs
+++ b/src/types/fiber.rs
@@ -1,7 +1,7 @@
 //! Janet fibers (soft threads) type.
 use core::{iter::FusedIterator, marker::PhantomData};
 
-use evil_janet::JanetFiber as CJanetFiber;
+use evil_janet::{JanetFiber as CJanetFiber, JanetType};
 use janetrs_macros::cjvg;
 
 use super::{Janet, JanetFunction, JanetSignal, JanetTable};
@@ -309,7 +309,8 @@ impl FusedIterator for Exec<'_, '_> {}
 ///
 /// It mostly corresponds to signals.
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-#[repr(u32)]
+#[cfg_attr(windows, repr(i32))]
+#[cfg_attr(not(windows), repr(u32))]
 pub enum FiberStatus {
     Dead  = evil_janet::JanetFiberStatus_JANET_STATUS_DEAD,
     Error = evil_janet::JanetFiberStatus_JANET_STATUS_ERROR,
@@ -330,9 +331,9 @@ pub enum FiberStatus {
 }
 
 #[allow(non_upper_case_globals)]
-impl From<u32> for FiberStatus {
+impl From<JanetType> for FiberStatus {
     #[inline]
-    fn from(val: u32) -> Self {
+    fn from(val: JanetType) -> Self {
         match val {
             evil_janet::JanetFiberStatus_JANET_STATUS_DEAD => Self::Dead,
             evil_janet::JanetFiberStatus_JANET_STATUS_ERROR => Self::Error,

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -308,6 +308,8 @@ impl fmt::Debug for JanetFunction<'_> {
 mod trystate {
     use core::mem::MaybeUninit;
 
+    use evil_janet::JanetType;
+
     use crate::{Janet, JanetSignal};
 
     /// A structure that holds the old and new states of the Janet VM.
@@ -358,7 +360,7 @@ mod trystate {
         pub unsafe fn signal_unchecked(&mut self) -> JanetSignal {
             let signal = evil_janet::_setjmp(self.inner.buf.as_mut_ptr());
 
-            JanetSignal::from(signal as u32)
+            JanetSignal::from(signal as JanetType)
         }
 
         /// Get the [`JanetSignal`] of the state if the environment is set to catch Janet

--- a/src/types/io.rs
+++ b/src/types/io.rs
@@ -220,9 +220,9 @@ impl Seek for JanetFile {
                 SeekFrom::Start(offset) => {
                     libc::fseek(self.as_file_ptr(), offset as _, libc::SEEK_SET)
                 },
-                SeekFrom::End(offset) => libc::fseek(self.as_file_ptr(), offset, libc::SEEK_END),
+                SeekFrom::End(offset) => libc::fseek(self.as_file_ptr(), offset as _, libc::SEEK_END),
                 SeekFrom::Current(offset) => {
-                    libc::fseek(self.as_file_ptr(), offset, libc::SEEK_CUR)
+                    libc::fseek(self.as_file_ptr(), offset as _, libc::SEEK_CUR)
                 },
             }
         };


### PR DESCRIPTION
This PR changes the use of u32 to `evil_janet::JanetType` to make it compile on windows. More details on why are in the other PR: https://github.com/GrayJack/evil-janet/pull/4